### PR TITLE
crafting provider

### DIFF
--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/kind/pkg/cluster/internal/delete"
 	"sigs.k8s.io/kind/pkg/cluster/internal/providers"
+	"sigs.k8s.io/kind/pkg/cluster/internal/providers/crafting"
 	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/internal/apis/config"
 	"sigs.k8s.io/kind/pkg/internal/apis/config/encoding"
@@ -249,8 +250,11 @@ func validateProvider(p providers.Provider) error {
 		if !info.Cgroup2 {
 			return errors.New("running kind with rootless provider requires cgroup v2, see https://kind.sigs.k8s.io/docs/user/rootless/")
 		}
-		if !info.SupportsMemoryLimit || !info.SupportsPidsLimit || !info.SupportsCPUShares {
-			return errors.New("running kind with rootless provider requires setting systemd property \"Delegate=yes\", see https://kind.sigs.k8s.io/docs/user/rootless/")
+		// Do not check systemd if running kind in sandbox workspace.
+		if !crafting.InSandboxWorkspace() {
+			if !info.SupportsMemoryLimit || !info.SupportsPidsLimit || !info.SupportsCPUShares {
+				return errors.New("running kind with rootless provider requires setting systemd property \"Delegate=yes\", see https://kind.sigs.k8s.io/docs/user/rootless/")
+			}
 		}
 	}
 	return nil

--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -254,11 +254,8 @@ func validateProvider(p providers.Provider) error {
 		if !info.Cgroup2 {
 			return errors.New("running kind with rootless provider requires cgroup v2, see https://kind.sigs.k8s.io/docs/user/rootless/")
 		}
-		// Do not check systemd if running kind in sandbox workspace.
-		if !crafting.InSandboxWorkspace() {
-			if !info.SupportsMemoryLimit || !info.SupportsPidsLimit || !info.SupportsCPUShares {
-				return errors.New("running kind with rootless provider requires setting systemd property \"Delegate=yes\", see https://kind.sigs.k8s.io/docs/user/rootless/")
-			}
+		if !info.SupportsMemoryLimit || !info.SupportsPidsLimit || !info.SupportsCPUShares {
+			return errors.New("running kind with rootless provider requires setting systemd property \"Delegate=yes\", see https://kind.sigs.k8s.io/docs/user/rootless/")
 		}
 	}
 	return nil

--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -25,7 +25,6 @@ import (
 
 	"sigs.k8s.io/kind/pkg/cluster/internal/delete"
 	"sigs.k8s.io/kind/pkg/cluster/internal/providers"
-	"sigs.k8s.io/kind/pkg/cluster/internal/providers/crafting"
 	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/internal/apis/config"
 	"sigs.k8s.io/kind/pkg/internal/apis/config/encoding"
@@ -116,10 +115,6 @@ func Cluster(logger log.Logger, p providers.Provider, opts *ClusterOptions) erro
 		actionsToRun = append(actionsToRun,
 			kubeadminit.NewAction(opts.Config), // run kubeadm init
 		)
-		// Crafting: patch kube-proxy
-		if crafting.InSandboxWorkspace() {
-			actionsToRun = append(actionsToRun, crafting.NewKubeProxyPatchAction(p, opts.Config))
-		}
 		// this step might be skipped, but is next after init
 		if !opts.Config.Networking.DisableDefaultCNI {
 			actionsToRun = append(actionsToRun,

--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -160,6 +160,10 @@ func Cluster(logger log.Logger, p providers.Provider, opts *ClusterOptions) erro
 		return err
 	}
 
+	if err = crafting.PatchKubeProxy(p, opts.Config.Name); err != nil {
+		return err
+	}
+
 	// optionally display usage
 	if opts.DisplayUsage {
 		logUsage(logger, opts.Config.Name, opts.KubeconfigPath)

--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -116,6 +116,10 @@ func Cluster(logger log.Logger, p providers.Provider, opts *ClusterOptions) erro
 		actionsToRun = append(actionsToRun,
 			kubeadminit.NewAction(opts.Config), // run kubeadm init
 		)
+		// Crafting: patch kube-proxy
+		if crafting.InSandboxWorkspace() {
+			actionsToRun = append(actionsToRun, crafting.NewKubeProxyPatchAction(p, opts.Config))
+		}
 		// this step might be skipped, but is next after init
 		if !opts.Config.Networking.DisableDefaultCNI {
 			actionsToRun = append(actionsToRun,
@@ -157,10 +161,6 @@ func Cluster(logger log.Logger, p providers.Provider, opts *ClusterOptions) erro
 		}
 	}
 	if err != nil {
-		return err
-	}
-
-	if err = crafting.PatchKubeProxy(p, opts.Config.Name); err != nil {
 		return err
 	}
 

--- a/pkg/cluster/internal/providers/crafting/OWNERS
+++ b/pkg/cluster/internal/providers/crafting/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/provider/docker

--- a/pkg/cluster/internal/providers/crafting/OWNERS
+++ b/pkg/cluster/internal/providers/crafting/OWNERS
@@ -1,2 +1,2 @@
 labels:
-- area/provider/docker
+- area/provider/crafting

--- a/pkg/cluster/internal/providers/crafting/constants.go
+++ b/pkg/cluster/internal/providers/crafting/constants.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or impliep.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crafting
+
+// clusterLabelKey is applied to each "node" docker container for identification
+const clusterLabelKey = "io.x-k8s.kind.cluster"
+
+// nodeRoleLabelKey is applied to each "node" docker container for categorization
+// of nodes by role
+const nodeRoleLabelKey = "io.x-k8s.kind.role"

--- a/pkg/cluster/internal/providers/crafting/crafting.go
+++ b/pkg/cluster/internal/providers/crafting/crafting.go
@@ -1,7 +1,13 @@
 package crafting
 
 import (
+	"bytes"
+	"fmt"
 	"os"
+
+	"sigs.k8s.io/kind/pkg/cluster/internal/providers"
+	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
+	"sigs.k8s.io/kind/pkg/errors"
 )
 
 func InSandboxWorkspace() bool {
@@ -12,4 +18,30 @@ func InSandboxWorkspace() bool {
 
 func IsAvailable() bool {
 	return InSandboxWorkspace()
+}
+
+func PatchKubeProxy(p providers.Provider, name string) error {
+	// find a control plane node to patch kube-proxy
+	n, err := p.ListNodes(name)
+	if err != nil {
+		return err
+	}
+	nodes, err := nodeutils.ControlPlaneNodes(n)
+	if err != nil {
+		return err
+	}
+	if len(nodes) < 1 {
+		return errors.Errorf("could not locate any control plane nodes for cluster named '%s'. "+
+			"Use the --name option to select a different cluster", name)
+	}
+	var buff bytes.Buffer
+	node := nodes[0]
+	if err = node.Command(
+		"kubectl", "-n", "kube-system", "patch", "ds", "kube-proxy", "--type", "json",
+		"-p", "[{'op': 'replace', 'path': '/spec/template/spec/containers/0/securityContext', 'value':{'capabilities':{'add':['NET_ADMIN']}}}]").
+		SetStderr(&buff).Run(); err != nil {
+		return fmt.Errorf("patch kube-system capabilities error: %w, %s", err, buff.String())
+	}
+
+	return nil
 }

--- a/pkg/cluster/internal/providers/crafting/crafting.go
+++ b/pkg/cluster/internal/providers/crafting/crafting.go
@@ -1,0 +1,15 @@
+package crafting
+
+import (
+	"os"
+)
+
+func InSandboxWorkspace() bool {
+	// TODO. Better way to check.
+	_, ok := os.LookupEnv("SANDBOX_NAME")
+	return ok
+}
+
+func IsAvailable() bool {
+	return InSandboxWorkspace()
+}

--- a/pkg/cluster/internal/providers/crafting/crafting.go
+++ b/pkg/cluster/internal/providers/crafting/crafting.go
@@ -1,55 +1,10 @@
 package crafting
 
 import (
-	"bytes"
-	"fmt"
 	"os"
-
-	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions"
-	"sigs.k8s.io/kind/pkg/cluster/internal/providers"
-	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
-	"sigs.k8s.io/kind/pkg/errors"
-	"sigs.k8s.io/kind/pkg/internal/apis/config"
 )
 
-type kubeProxyPatchAction struct {
-	p   providers.Provider
-	cfg *config.Cluster
-}
-
-func NewKubeProxyPatchAction(p providers.Provider, cfg *config.Cluster) actions.Action {
-	return &kubeProxyPatchAction{p: p, cfg: cfg}
-}
-
-func (a *kubeProxyPatchAction) Execute(ctx *actions.ActionContext) error {
-	name := a.cfg.Name
-	// find a control plane node to patch kube-proxy
-	n, err := a.p.ListNodes(name)
-	if err != nil {
-		return err
-	}
-	nodes, err := nodeutils.ControlPlaneNodes(n)
-	if err != nil {
-		return err
-	}
-	if len(nodes) < 1 {
-		return errors.Errorf("could not locate any control plane nodes for cluster named '%s'. "+
-			"Use the --name option to select a different cluster", name)
-	}
-	var buff bytes.Buffer
-	node := nodes[0]
-	if err = node.Command(
-		"kubectl", "-n", "kube-system", "patch", "ds", "kube-proxy", "--type", "json",
-		"-p", "[{'op': 'replace', 'path': '/spec/template/spec/containers/0/securityContext', 'value':{'capabilities':{'add':['NET_ADMIN']}}}]").
-		SetStderr(&buff).Run(); err != nil {
-		return fmt.Errorf("patch kube-system capabilities error: %w, %s", err, buff.String())
-	}
-
-	return nil
-}
-
 func InSandboxWorkspace() bool {
-	// TODO. Better way to check.
 	_, err := os.Stat("/run/sandbox/svc/workspace.sock")
 	return err == nil
 }

--- a/pkg/cluster/internal/providers/crafting/images.go
+++ b/pkg/cluster/internal/providers/crafting/images.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crafting
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/kind/pkg/errors"
+	"sigs.k8s.io/kind/pkg/exec"
+	"sigs.k8s.io/kind/pkg/log"
+
+	"sigs.k8s.io/kind/pkg/cluster/internal/providers/common"
+	"sigs.k8s.io/kind/pkg/internal/apis/config"
+	"sigs.k8s.io/kind/pkg/internal/cli"
+)
+
+// ensureNodeImages ensures that the node images used by the create
+// configuration are present
+func ensureNodeImages(logger log.Logger, status *cli.Status, cfg *config.Cluster) error {
+	// pull each required image
+	for _, image := range common.RequiredNodeImages(cfg).List() {
+		// prints user friendly message
+		friendlyImageName, image := sanitizeImage(image)
+		status.Start(fmt.Sprintf("Ensuring node image (%s) 🖼", friendlyImageName))
+		if _, err := pullIfNotPresent(logger, image, 4); err != nil {
+			status.End(false)
+			return err
+		}
+	}
+	return nil
+}
+
+// pullIfNotPresent will pull an image if it is not present locally
+// retrying up to retries times
+// it returns true if it attempted to pull, and any errors from pulling
+func pullIfNotPresent(logger log.Logger, image string, retries int) (pulled bool, err error) {
+	// TODO(bentheelder): switch most (all) of the logging here to debug level
+	// once we have configurable log levels
+	// if this did not return an error, then the image exists locally
+	cmd := exec.Command("docker", "inspect", "--type=image", image)
+	if err := cmd.Run(); err == nil {
+		logger.V(1).Infof("Image: %s present locally", image)
+		return false, nil
+	}
+	// otherwise try to pull it
+	return true, pull(logger, image, retries)
+}
+
+// pull pulls an image, retrying up to retries times
+func pull(logger log.Logger, image string, retries int) error {
+	logger.V(1).Infof("Pulling image: %s ...", image)
+	err := exec.Command("docker", "pull", image).Run()
+	// retry pulling up to retries times if necessary
+	if err != nil {
+		for i := 0; i < retries; i++ {
+			time.Sleep(time.Second * time.Duration(i+1))
+			logger.V(1).Infof("Trying again to pull image: %q ... %v", image, err)
+			// TODO(bentheelder): add some backoff / sleep?
+			err = exec.Command("docker", "pull", image).Run()
+			if err == nil {
+				break
+			}
+		}
+	}
+	return errors.Wrapf(err, "failed to pull image %q", image)
+}
+
+// sanitizeImage is a helper to return human readable image name and
+// the docker pullable image name from the provided image
+func sanitizeImage(image string) (string, string) {
+	if strings.Contains(image, "@sha256:") {
+		return strings.Split(image, "@sha256:")[0], image
+	}
+	return image, image
+}

--- a/pkg/cluster/internal/providers/crafting/network.go
+++ b/pkg/cluster/internal/providers/crafting/network.go
@@ -1,0 +1,332 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crafting
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"sigs.k8s.io/kind/pkg/errors"
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+// This may be overridden by KIND_EXPERIMENTAL_DOCKER_NETWORK env,
+// experimentally...
+//
+// By default currently picking a single network is equivalent to the previous
+// behavior *except* that we moved from the default bridge to a user defined
+// network because the default bridge is actually special versus any other
+// docker network and lacks the embedded DNS
+//
+// For now this also makes it easier for apps to join the same network, and
+// leaves users with complex networking desires to create and manage their own
+// networks.
+const fixedNetworkName = "kind"
+
+// ensureNetwork checks if docker network by name exists, if not it creates it
+func ensureNetwork(name string) error {
+	// check if network exists already and remove any duplicate networks
+	exists, err := removeDuplicateNetworks(name)
+	if err != nil {
+		return err
+	}
+
+	// network already exists, we're good
+	// TODO: the network might already exist and not have ipv6 ... :|
+	// discussion: https://github.com/kubernetes-sigs/kind/pull/1508#discussion_r414594198
+	if exists {
+		return nil
+	}
+
+	// Create ipv4 network
+	mtu := getDefaultNetworkMTU()
+	return createNetworkNoDuplicates(name, "", mtu)
+
+	// Generate unique subnet per network based on the name
+	// obtained from the ULA fc00::/8 range
+	// Use the MTU configured for the docker default network
+	// Make N attempts with "probing" in case we happen to collide
+	subnet := generateULASubnetFromName(name, 0)
+	err = createNetworkNoDuplicates(name, subnet, mtu)
+	if err == nil {
+		// Success!
+		return nil
+	}
+
+	// On the first try check if ipv6 fails entirely on this machine
+	// https://github.com/kubernetes-sigs/kind/issues/1544
+	// Otherwise if it's not a pool overlap error, fail
+	// If it is, make more attempts below
+	if isIPv6UnavailableError(err) {
+		// only one attempt, IPAM is automatic in ipv4 only
+		return createNetworkNoDuplicates(name, "", mtu)
+	}
+	if isPoolOverlapError(err) {
+		// pool overlap suggests perhaps another process created the network
+		// check if network exists already and remove any duplicate networks
+		exists, err := checkIfNetworkExists(name)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return nil
+		}
+		// otherwise we'll start trying with different subnets
+	} else {
+		// unknown error ...
+		return err
+	}
+
+	// keep trying for ipv6 subnets
+	const maxAttempts = 5
+	for attempt := int32(1); attempt < maxAttempts; attempt++ {
+		subnet := generateULASubnetFromName(name, attempt)
+		err = createNetworkNoDuplicates(name, subnet, mtu)
+		if err == nil {
+			// success!
+			return nil
+		}
+		if isPoolOverlapError(err) {
+			// pool overlap suggests perhaps another process created the network
+			// check if network exists already and remove any duplicate networks
+			exists, err := checkIfNetworkExists(name)
+			if err != nil {
+				return err
+			}
+			if exists {
+				return nil
+			}
+			// otherwise we'll try again
+			continue
+		}
+		// unknown error ...
+		return err
+	}
+	return errors.New("exhausted attempts trying to find a non-overlapping subnet")
+}
+
+func createNetworkNoDuplicates(name, ipv6Subnet string, mtu int) error {
+	if err := createNetwork(name, ipv6Subnet, mtu); err != nil && !isNetworkAlreadyExistsError(err) {
+		return err
+	}
+	_, err := removeDuplicateNetworks(name)
+	return err
+}
+
+func removeDuplicateNetworks(name string) (bool, error) {
+	networks, err := sortedNetworksWithName(name)
+	if err != nil {
+		return false, err
+	}
+	if len(networks) > 1 {
+		if err := deleteNetworks(networks[1:]...); err != nil && !isOnlyErrorNoSuchNetwork(err) {
+			return false, err
+		}
+	}
+	return len(networks) > 0, nil
+}
+
+func createNetwork(name, ipv6Subnet string, mtu int) error {
+	args := []string{"network", "create", "-d=bridge",
+		"-o", "com.docker.network.bridge.enable_ip_masquerade=true",
+	}
+	if mtu > 0 {
+		args = append(args, "-o", fmt.Sprintf("com.docker.network.driver.mtu=%d", mtu))
+	}
+	if ipv6Subnet != "" {
+		args = append(args, "--ipv6", "--subnet", ipv6Subnet)
+	}
+	args = append(args, name)
+	return exec.Command("docker", args...).Run()
+}
+
+// getDefaultNetworkMTU obtains the MTU from the docker default network
+func getDefaultNetworkMTU() int {
+	cmd := exec.Command("docker", "network", "inspect", "bridge",
+		"-f", `{{ index .Options "com.docker.network.driver.mtu" }}`)
+	lines, err := exec.OutputLines(cmd)
+	if err != nil || len(lines) != 1 {
+		return 0
+	}
+	mtu, err := strconv.Atoi(lines[0])
+	if err != nil {
+		return 0
+	}
+	return mtu
+}
+
+func sortedNetworksWithName(name string) ([]string, error) {
+	// query which networks exist with the name
+	ids, err := networksWithName(name)
+	if err != nil {
+		return nil, err
+	}
+	// we can skip sorting if there are less than 2
+	if len(ids) < 2 {
+		return ids, nil
+	}
+	// inspect them to get more detail for sorting
+	networks, err := inspectNetworks(ids)
+	if err != nil {
+		return nil, err
+	}
+	// deterministically sort networks
+	// NOTE: THIS PART IS IMPORTANT!
+	sortNetworkInspectEntries(networks)
+	// return network IDs
+	sortedIDs := make([]string, 0, len(networks))
+	for i := range networks {
+		sortedIDs = append(sortedIDs, networks[i].ID)
+	}
+	return sortedIDs, nil
+}
+
+func sortNetworkInspectEntries(networks []networkInspectEntry) {
+	sort.Slice(networks, func(i, j int) bool {
+		// we want networks with active containers first
+		if len(networks[i].Containers) > len(networks[j].Containers) {
+			return true
+		}
+		return networks[i].ID < networks[j].ID
+	})
+}
+
+func inspectNetworks(networkIDs []string) ([]networkInspectEntry, error) {
+	inspectOut, err := exec.Output(exec.Command("docker", append([]string{"network", "inspect"}, networkIDs...)...))
+	// NOTE: the caller can detect if the network isn't present in the output anyhow
+	// we don't want to fail on this here.
+	if err != nil && !isOnlyErrorNoSuchNetwork(err) {
+		return nil, err
+	}
+	// parse
+	networks := []networkInspectEntry{}
+	if err := json.Unmarshal(inspectOut, &networks); err != nil {
+		return nil, errors.Wrap(err, "failed to decode networks list")
+	}
+	return networks, nil
+}
+
+type networkInspectEntry struct {
+	ID string `json:"Id"`
+	// NOTE: we don't care about the contents here but we need to parse
+	// how many entries exist in the containers map
+	Containers map[string]map[string]string `json:"Containers"`
+}
+
+// networksWithName returns a list of network IDs for networks with this name
+func networksWithName(name string) ([]string, error) {
+	lsOut, err := exec.Output(exec.Command(
+		"docker", "network", "ls",
+		"--filter=name=^"+regexp.QuoteMeta(name)+"$",
+		"--format={{.ID}}", // output as unambiguous IDs
+	))
+	if err != nil {
+		return nil, err
+	}
+	cleaned := strings.TrimSuffix(string(lsOut), "\n")
+	if cleaned == "" { // avoid returning []string{""}
+		return nil, nil
+	}
+	return strings.Split(cleaned, "\n"), nil
+}
+
+func checkIfNetworkExists(name string) (bool, error) {
+	out, err := exec.Output(exec.Command(
+		"docker", "network", "ls",
+		"--filter=name=^"+regexp.QuoteMeta(name)+"$",
+		"--format={{.Name}}",
+	))
+	return strings.HasPrefix(string(out), name), err
+}
+
+func isIPv6UnavailableError(err error) bool {
+	rerr := exec.RunErrorForError(err)
+	return rerr != nil && strings.HasPrefix(string(rerr.Output), "Error response from daemon: Cannot read IPv6 setup for bridge")
+}
+
+func isPoolOverlapError(err error) bool {
+	rerr := exec.RunErrorForError(err)
+	return rerr != nil && strings.HasPrefix(string(rerr.Output), "Error response from daemon: Pool overlaps with other one on this address space") || strings.Contains(string(rerr.Output), "networks have overlapping")
+}
+
+func isNetworkAlreadyExistsError(err error) bool {
+	rerr := exec.RunErrorForError(err)
+	return rerr != nil && strings.HasPrefix(string(rerr.Output), "Error response from daemon: network with name") && strings.Contains(string(rerr.Output), "already exists")
+}
+
+// returns true if:
+// - err only contains no such network errors
+func isOnlyErrorNoSuchNetwork(err error) bool {
+	rerr := exec.RunErrorForError(err)
+	if rerr == nil {
+		return false
+	}
+	// check all lines of output from errored command
+	b := bytes.NewBuffer(rerr.Output)
+	for {
+		l, err := b.ReadBytes('\n')
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return false
+		}
+		// if the line begins with Error: No such network: it's fine
+		s := string(l)
+		if strings.HasPrefix(s, "Error: No such network:") {
+			continue
+		}
+		// other errors are not fine
+		if strings.HasPrefix(s, "Error: ") {
+			return false
+		}
+		// other line contents should just be network references
+	}
+	return true
+}
+
+func deleteNetworks(networks ...string) error {
+	return exec.Command("docker", append([]string{"network", "rm"}, networks...)...).Run()
+}
+
+// generateULASubnetFromName generate an IPv6 subnet based on the
+// name and Nth probing attempt
+func generateULASubnetFromName(name string, attempt int32) string {
+	ip := make([]byte, 16)
+	ip[0] = 0xfc
+	ip[1] = 0x00
+	h := sha1.New()
+	_, _ = h.Write([]byte(name))
+	_ = binary.Write(h, binary.LittleEndian, attempt)
+	bs := h.Sum(nil)
+	for i := 2; i < 8; i++ {
+		ip[i] = bs[i]
+	}
+	subnet := &net.IPNet{
+		IP:   net.IP(ip),
+		Mask: net.CIDRMask(64, 128),
+	}
+	return subnet.String()
+}

--- a/pkg/cluster/internal/providers/crafting/network.go
+++ b/pkg/cluster/internal/providers/crafting/network.go
@@ -61,7 +61,7 @@ func ensureNetwork(name string) error {
 		return nil
 	}
 
-	// Create ipv4 network
+	// Crafting: Create ipv4 network
 	mtu := getDefaultNetworkMTU()
 	return createNetworkNoDuplicates(name, "", mtu)
 }

--- a/pkg/cluster/internal/providers/crafting/network_integration_test.go
+++ b/pkg/cluster/internal/providers/crafting/network_integration_test.go
@@ -1,0 +1,82 @@
+//go:build !nointegration
+// +build !nointegration
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crafting
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"sigs.k8s.io/kind/pkg/errors"
+	"sigs.k8s.io/kind/pkg/exec"
+
+	"sigs.k8s.io/kind/pkg/internal/integration"
+)
+
+func TestIntegrationEnsureNetworkConcurrent(t *testing.T) {
+	integration.MaybeSkip(t)
+
+	testNetworkName := "integration-test-ensure-kind-network"
+
+	// cleanup
+	cleanup := func() {
+		ids, _ := networksWithName(testNetworkName)
+		if len(ids) > 0 {
+			_ = deleteNetworks(ids...)
+		}
+	}
+	cleanup()
+	defer cleanup()
+
+	// this is more than enough to trigger race conditions
+	networkConcurrency := 10
+
+	// Create multiple networks concurrently
+	errCh := make(chan error, networkConcurrency)
+	for i := 0; i < networkConcurrency; i++ {
+		go func() {
+			errCh <- ensureNetwork(testNetworkName)
+		}()
+	}
+	for i := 0; i < networkConcurrency; i++ {
+		if err := <-errCh; err != nil {
+			t.Errorf("error creating network: %v", err)
+			rerr := exec.RunErrorForError(err)
+			if rerr != nil {
+				t.Errorf("%q", rerr.Output)
+			}
+			t.Errorf("%+v", errors.StackTrace(err))
+		}
+	}
+
+	cmd := exec.Command(
+		"docker", "network", "ls",
+		fmt.Sprintf("--filter=name=^%s$", regexp.QuoteMeta(testNetworkName)),
+		"--format={{.Name}}",
+	)
+
+	lines, err := exec.OutputLines(cmd)
+	if err != nil {
+		t.Errorf("obtaining the docker networks")
+	}
+	if len(lines) != 1 {
+		t.Errorf("wrong number of networks created: %d", len(lines))
+	}
+}

--- a/pkg/cluster/internal/providers/crafting/network_test.go
+++ b/pkg/cluster/internal/providers/crafting/network_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crafting
+
+import (
+	"fmt"
+	"testing"
+
+	"sigs.k8s.io/kind/pkg/internal/assert"
+)
+
+func Test_generateULASubnetFromName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		attempt int32
+		subnet  string
+	}{
+		{
+			name:   "kind",
+			subnet: "fc00:f853:ccd:e793::/64",
+		},
+		{
+			name:    "foo",
+			attempt: 1,
+			subnet:  "fc00:8edf:7f02:ec8f::/64",
+		},
+		{
+			name:    "foo",
+			attempt: 2,
+			subnet:  "fc00:9968:306b:2c65::/64",
+		},
+		{
+			name:   "kind2",
+			subnet: "fc00:444c:147a:44ab::/64",
+		},
+		{
+			name:   "kin",
+			subnet: "fc00:fcd9:c2be:8e23::/64",
+		},
+		{
+			name:   "mysupernetwork",
+			subnet: "fc00:7ae1:1e0d:b4d4::/64",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc // capture variable
+		t.Run(fmt.Sprintf("%s,%d", tc.name, tc.attempt), func(t *testing.T) {
+			t.Parallel()
+			subnet := generateULASubnetFromName(tc.name, tc.attempt)
+			if subnet != tc.subnet {
+				t.Errorf("Wrong subnet from %v: expected %v, received %v", tc.name, tc.subnet, subnet)
+			}
+		})
+	}
+}
+
+func Test_sortNetworkInspectEntries(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Networks []networkInspectEntry
+		Sorted   []networkInspectEntry
+	}{
+		{
+			Name: "simple ID sort",
+			Networks: []networkInspectEntry{
+				{
+					ID: "dc7f897c237215c3b73d2c9ba1d4e116d872793a6c1c0e5bf083762998de8b4e",
+				},
+				{
+					ID: "1ed9912325a0d08594ee786de91ebd961e631643877b5ee58ec906b640813eae",
+				},
+			},
+			Sorted: []networkInspectEntry{
+				{
+					ID: "1ed9912325a0d08594ee786de91ebd961e631643877b5ee58ec906b640813eae",
+				},
+				{
+					ID: "dc7f897c237215c3b73d2c9ba1d4e116d872793a6c1c0e5bf083762998de8b4e",
+				},
+			},
+		},
+		{
+			Name: "containers attached sort",
+			Networks: []networkInspectEntry{
+				{
+					ID: "1ed9912325a0d08594ee786de91ebd961e631643877b5ee58ec906b640813eae",
+				},
+				{
+					ID: "dc7f897c237215c3b73d2c9ba1d4e116d872793a6c1c0e5bf083762998de8b4e",
+					Containers: map[string]map[string]string{
+						"a37779e06f3b694eba491dd450aad18bbbaa0a0fce2952e7c9195ea45ae79d41": {
+							"Name":       "buildx_buildkit_kind-builder0",
+							"EndpointID": "8f6411fb4360059b2f91028f91ef03130abc96d6381afc265ce53c9df89d5a3d",
+						},
+					},
+				},
+				{
+					ID: "f0445f08b9989921da00250d778975202267fbab364e5fbad0ceb6db24f3f91e",
+				},
+				{
+					ID: "128154205c7d88c7bb9c255d389bc9e222b58a48cf83619976e7665a48e79918",
+					Containers: map[string]map[string]string{
+						"aad18bbbaa0a0fce2952e7c9195ea45ae79d41a37779e06f3b694eba491dd450": {
+							"Name":       "fakey-fake",
+							"EndpointID": "f03130abc96d6381afc265ce53c9df89d5a3d8f6411fb4360059b2f91028f91e",
+						},
+					},
+				},
+			},
+			Sorted: []networkInspectEntry{
+				{
+					ID: "128154205c7d88c7bb9c255d389bc9e222b58a48cf83619976e7665a48e79918",
+					Containers: map[string]map[string]string{
+						"aad18bbbaa0a0fce2952e7c9195ea45ae79d41a37779e06f3b694eba491dd450": {
+							"Name":       "fakey-fake",
+							"EndpointID": "f03130abc96d6381afc265ce53c9df89d5a3d8f6411fb4360059b2f91028f91e",
+						},
+					},
+				},
+				{
+					ID: "dc7f897c237215c3b73d2c9ba1d4e116d872793a6c1c0e5bf083762998de8b4e",
+					Containers: map[string]map[string]string{
+						"a37779e06f3b694eba491dd450aad18bbbaa0a0fce2952e7c9195ea45ae79d41": {
+							"Name":       "buildx_buildkit_kind-builder0",
+							"EndpointID": "8f6411fb4360059b2f91028f91ef03130abc96d6381afc265ce53c9df89d5a3d",
+						},
+					},
+				},
+				{
+					ID: "1ed9912325a0d08594ee786de91ebd961e631643877b5ee58ec906b640813eae",
+				},
+				{
+					ID: "f0445f08b9989921da00250d778975202267fbab364e5fbad0ceb6db24f3f91e",
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			toSort := make([]networkInspectEntry, len(tc.Networks))
+			copy(toSort, tc.Networks)
+			sortNetworkInspectEntries(toSort)
+			assert.DeepEqual(t, tc.Sorted, toSort)
+		})
+	}
+}

--- a/pkg/cluster/internal/providers/crafting/node.go
+++ b/pkg/cluster/internal/providers/crafting/node.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or impliep.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crafting
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"sigs.k8s.io/kind/pkg/errors"
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+// nodes.Node implementation for the docker provider
+type node struct {
+	name string
+}
+
+func (n *node) String() string {
+	return n.name
+}
+
+func (n *node) Role() (string, error) {
+	cmd := exec.Command("docker", "inspect",
+		"--format", fmt.Sprintf(`{{ index .Config.Labels "%s"}}`, nodeRoleLabelKey),
+		n.name,
+	)
+	lines, err := exec.OutputLines(cmd)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get role for node")
+	}
+	if len(lines) != 1 {
+		return "", errors.Errorf("failed to get role for node: output lines %d != 1", len(lines))
+	}
+	return lines[0], nil
+}
+
+func (n *node) IP() (ipv4 string, ipv6 string, err error) {
+	// retrieve the IP address of the node using docker inspect
+	cmd := exec.Command("docker", "inspect",
+		"-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}",
+		n.name, // ... against the "node" container
+	)
+	lines, err := exec.OutputLines(cmd)
+	if err != nil {
+		return "", "", errors.Wrap(err, "failed to get container details")
+	}
+	if len(lines) != 1 {
+		return "", "", errors.Errorf("file should only be one line, got %d lines", len(lines))
+	}
+	ips := strings.Split(lines[0], ",")
+	if len(ips) != 2 {
+		return "", "", errors.Errorf("container addresses should have 2 values, got %d values", len(ips))
+	}
+	return ips[0], ips[1], nil
+}
+
+func (n *node) Command(command string, args ...string) exec.Cmd {
+	return &nodeCmd{
+		nameOrID: n.name,
+		command:  command,
+		args:     args,
+	}
+}
+
+func (n *node) CommandContext(ctx context.Context, command string, args ...string) exec.Cmd {
+	return &nodeCmd{
+		nameOrID: n.name,
+		command:  command,
+		args:     args,
+		ctx:      ctx,
+	}
+}
+
+// nodeCmd implements exec.Cmd for docker nodes
+type nodeCmd struct {
+	nameOrID string // the container name or ID
+	command  string
+	args     []string
+	env      []string
+	stdin    io.Reader
+	stdout   io.Writer
+	stderr   io.Writer
+	ctx      context.Context
+}
+
+func (c *nodeCmd) Run() error {
+	args := []string{
+		"exec",
+	}
+	if c.stdin != nil {
+		args = append(args,
+			"-i", // interactive so we can supply input
+		)
+	}
+	// set env
+	for _, env := range c.env {
+		args = append(args, "-e", env)
+	}
+	// specify the container and command, after this everything will be
+	// args the command in the container rather than to docker
+	args = append(
+		args,
+		c.nameOrID, // ... against the container
+		c.command,  // with the command specified
+	)
+	args = append(
+		args,
+		// finally, with the caller args
+		c.args...,
+	)
+	var cmd exec.Cmd
+	if c.ctx != nil {
+		cmd = exec.CommandContext(c.ctx, "docker", args...)
+	} else {
+		cmd = exec.Command("docker", args...)
+	}
+	if c.stdin != nil {
+		cmd.SetStdin(c.stdin)
+	}
+	if c.stderr != nil {
+		cmd.SetStderr(c.stderr)
+	}
+	if c.stdout != nil {
+		cmd.SetStdout(c.stdout)
+	}
+	return cmd.Run()
+}
+
+func (c *nodeCmd) SetEnv(env ...string) exec.Cmd {
+	c.env = env
+	return c
+}
+
+func (c *nodeCmd) SetStdin(r io.Reader) exec.Cmd {
+	c.stdin = r
+	return c
+}
+
+func (c *nodeCmd) SetStdout(w io.Writer) exec.Cmd {
+	c.stdout = w
+	return c
+}
+
+func (c *nodeCmd) SetStderr(w io.Writer) exec.Cmd {
+	c.stderr = w
+	return c
+}
+
+func (n *node) SerialLogs(w io.Writer) error {
+	return exec.Command("docker", "logs", n.name).SetStdout(w).SetStderr(w).Run()
+}

--- a/pkg/cluster/internal/providers/crafting/node.go
+++ b/pkg/cluster/internal/providers/crafting/node.go
@@ -101,6 +101,7 @@ type nodeCmd struct {
 
 func (c *nodeCmd) Run() error {
 	args := []string{
+		// Crafting
 		"exec",
 	}
 	if c.stdin != nil {

--- a/pkg/cluster/internal/providers/crafting/node.go
+++ b/pkg/cluster/internal/providers/crafting/node.go
@@ -101,7 +101,7 @@ type nodeCmd struct {
 
 func (c *nodeCmd) Run() error {
 	args := []string{
-		// Crafting
+		// Crafting:
 		"exec",
 	}
 	if c.stdin != nil {

--- a/pkg/cluster/internal/providers/crafting/provider.go
+++ b/pkg/cluster/internal/providers/crafting/provider.go
@@ -17,7 +17,6 @@ limitations under the License.
 package crafting
 
 import (
-	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -322,20 +321,8 @@ func info() (*providers.ProviderInfo, error) {
 	info.SupportsPidsLimit = true
 	info.SupportsCPUShares = true
 
-	for _, o := range dInfo.SecurityOptions {
-		// o is like "name=seccomp,profile=default", or "name=rootless",
-		csvReader := csv.NewReader(strings.NewReader(o))
-		sliceSlice, err := csvReader.ReadAll()
-		if err != nil {
-			return nil, err
-		}
-		for _, f := range sliceSlice {
-			for _, ff := range f {
-				if ff == "name=rootless" {
-					info.Rootless = true
-				}
-			}
-		}
-	}
+	// Crafting: For crafting provider, always rootless
+	info.Rootless = true
+
 	return &info, nil
 }

--- a/pkg/cluster/internal/providers/crafting/provider.go
+++ b/pkg/cluster/internal/providers/crafting/provider.go
@@ -317,14 +317,11 @@ func info() (*providers.ProviderInfo, error) {
 	info := providers.ProviderInfo{
 		Cgroup2: dInfo.CgroupVersion == "2",
 	}
-	// When CgroupDriver == "none", the MemoryLimit/PidsLimit/CPUShares
-	// values are meaningless and need to be considered false.
-	// https://github.com/moby/moby/issues/42151
-	if dInfo.CgroupDriver != "none" {
-		info.SupportsMemoryLimit = dInfo.MemoryLimit
-		info.SupportsPidsLimit = dInfo.PidsLimit
-		info.SupportsCPUShares = dInfo.CPUShares
-	}
+	// Crafting: In sandbox workspace, let's set these to true
+	info.SupportsMemoryLimit = true
+	info.SupportsPidsLimit = true
+	info.SupportsCPUShares = true
+
 	for _, o := range dInfo.SecurityOptions {
 		// o is like "name=seccomp,profile=default", or "name=rootless",
 		csvReader := csv.NewReader(strings.NewReader(o))

--- a/pkg/cluster/internal/providers/crafting/provider.go
+++ b/pkg/cluster/internal/providers/crafting/provider.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or impliep.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crafting
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/kind/pkg/cluster/nodes"
+	"sigs.k8s.io/kind/pkg/errors"
+	"sigs.k8s.io/kind/pkg/exec"
+	"sigs.k8s.io/kind/pkg/log"
+
+	internallogs "sigs.k8s.io/kind/pkg/cluster/internal/logs"
+	"sigs.k8s.io/kind/pkg/cluster/internal/providers"
+	"sigs.k8s.io/kind/pkg/cluster/internal/providers/common"
+	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
+	"sigs.k8s.io/kind/pkg/internal/apis/config"
+	"sigs.k8s.io/kind/pkg/internal/cli"
+	"sigs.k8s.io/kind/pkg/internal/sets"
+)
+
+// NewProvider returns a new provider based on executing `docker ...`
+func NewProvider(logger log.Logger) providers.Provider {
+	return &provider{
+		logger: logger,
+	}
+}
+
+// Provider implements provider.Provider
+// see NewProvider
+type provider struct {
+	logger log.Logger
+	info   *providers.ProviderInfo
+}
+
+// String implements fmt.Stringer
+// NOTE: the value of this should not currently be relied upon for anything!
+// This is only used for setting the Node's providerID
+func (p *provider) String() string {
+	return "docker"
+}
+
+// Provision is part of the providers.Provider interface
+func (p *provider) Provision(status *cli.Status, cfg *config.Cluster) (err error) {
+	// TODO: validate cfg
+	// ensure node images are pulled before actually provisioning
+	if err := ensureNodeImages(p.logger, status, cfg); err != nil {
+		return err
+	}
+
+	// ensure the pre-requisite network exists
+	networkName := fixedNetworkName
+	if n := os.Getenv("KIND_EXPERIMENTAL_DOCKER_NETWORK"); n != "" {
+		p.logger.Warn("WARNING: Overriding docker network due to KIND_EXPERIMENTAL_DOCKER_NETWORK")
+		p.logger.Warn("WARNING: Here be dragons! This is not supported currently.")
+		networkName = n
+	}
+	if err := ensureNetwork(networkName); err != nil {
+		return errors.Wrap(err, "failed to ensure docker network")
+	}
+
+	// actually provision the cluster
+	icons := strings.Repeat("📦 ", len(cfg.Nodes))
+	status.Start(fmt.Sprintf("Preparing nodes %s", icons))
+	defer func() { status.End(err == nil) }()
+
+	// plan creating the containers
+	createContainerFuncs, err := planCreation(cfg, networkName)
+	if err != nil {
+		return err
+	}
+
+	// actually create nodes
+	return errors.UntilErrorConcurrent(createContainerFuncs)
+}
+
+// ListClusters is part of the providers.Provider interface
+func (p *provider) ListClusters() ([]string, error) {
+	cmd := exec.Command("docker",
+		"ps",
+		"-a", // show stopped nodes
+		// filter for nodes with the cluster label
+		"--filter", "label="+clusterLabelKey,
+		// format to include the cluster name
+		"--format", fmt.Sprintf(`{{.Label "%s"}}`, clusterLabelKey),
+	)
+	lines, err := exec.OutputLines(cmd)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list clusters")
+	}
+	return sets.NewString(lines...).List(), nil
+}
+
+// ListNodes is part of the providers.Provider interface
+func (p *provider) ListNodes(cluster string) ([]nodes.Node, error) {
+	cmd := exec.Command("docker",
+		"ps",
+		"-a", // show stopped nodes
+		// filter for nodes with the cluster label
+		"--filter", fmt.Sprintf("label=%s=%s", clusterLabelKey, cluster),
+		// format to include the cluster name
+		"--format", `{{.Names}}`,
+	)
+	lines, err := exec.OutputLines(cmd)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list nodes")
+	}
+	// convert names to node handles
+	ret := make([]nodes.Node, 0, len(lines))
+	for _, name := range lines {
+		ret = append(ret, p.node(name))
+	}
+	return ret, nil
+}
+
+// DeleteNodes is part of the providers.Provider interface
+func (p *provider) DeleteNodes(n []nodes.Node) error {
+	if len(n) == 0 {
+		return nil
+	}
+	const command = "docker"
+	args := make([]string, 0, len(n)+3) // allocate once
+	args = append(args,
+		"rm",
+		"-f", // force the container to be delete now
+		"-v", // delete volumes
+	)
+	for _, node := range n {
+		args = append(args, node.String())
+	}
+	if err := exec.Command(command, args...).Run(); err != nil {
+		return errors.Wrap(err, "failed to delete nodes")
+	}
+	return nil
+}
+
+// GetAPIServerEndpoint is part of the providers.Provider interface
+func (p *provider) GetAPIServerEndpoint(cluster string) (string, error) {
+	// locate the node that hosts this
+	allNodes, err := p.ListNodes(cluster)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to list nodes")
+	}
+	n, err := nodeutils.APIServerEndpointNode(allNodes)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get api server endpoint")
+	}
+
+	// if the 'desktop.docker.io/ports/<PORT>/tcp' label is present,
+	// defer to its value for the api server endpoint
+	//
+	// For example:
+	// "Labels": {
+	// 	"desktop.docker.io/ports/6443/tcp": "10.0.1.7:6443",
+	// }
+	cmd := exec.Command(
+		"docker", "inspect",
+		"--format", fmt.Sprintf(
+			"{{ index .Config.Labels \"desktop.docker.io/ports/%d/tcp\" }}", common.APIServerInternalPort,
+		),
+		n.String(),
+	)
+	lines, err := exec.OutputLines(cmd)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get api server port")
+	}
+	if len(lines) == 1 && lines[0] != "" {
+		return lines[0], nil
+	}
+
+	// else, retrieve the specific port mapping via NetworkSettings.Ports
+	cmd = exec.Command(
+		"docker", "inspect",
+		"--format", fmt.Sprintf(
+			"{{ with (index (index .NetworkSettings.Ports \"%d/tcp\") 0) }}{{ printf \"%%s\t%%s\" .HostIp .HostPort }}{{ end }}", common.APIServerInternalPort,
+		),
+		n.String(),
+	)
+	lines, err = exec.OutputLines(cmd)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get api server port")
+	}
+	if len(lines) != 1 {
+		return "", errors.Errorf("network details should only be one line, got %d lines", len(lines))
+	}
+	parts := strings.Split(lines[0], "\t")
+	if len(parts) != 2 {
+		return "", errors.Errorf("network details should only be two parts, got %d", len(parts))
+	}
+
+	// join host and port
+	return net.JoinHostPort(parts[0], parts[1]), nil
+}
+
+// GetAPIServerInternalEndpoint is part of the providers.Provider interface
+func (p *provider) GetAPIServerInternalEndpoint(cluster string) (string, error) {
+	// locate the node that hosts this
+	allNodes, err := p.ListNodes(cluster)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to list nodes")
+	}
+	n, err := nodeutils.APIServerEndpointNode(allNodes)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get api server endpoint")
+	}
+	// NOTE: we're using the nodes's hostnames which are their names
+	return net.JoinHostPort(n.String(), fmt.Sprintf("%d", common.APIServerInternalPort)), nil
+}
+
+// node returns a new node handle for this provider
+func (p *provider) node(name string) nodes.Node {
+	return &node{
+		name: name,
+	}
+}
+
+// CollectLogs will populate dir with cluster logs and other debug files
+func (p *provider) CollectLogs(dir string, nodes []nodes.Node) error {
+	execToPathFn := func(cmd exec.Cmd, path string) func() error {
+		return func() error {
+			f, err := common.FileOnHost(path)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			return cmd.SetStdout(f).SetStderr(f).Run()
+		}
+	}
+	// construct a slice of methods to collect logs
+	fns := []func() error{
+		// record info about the host docker
+		execToPathFn(
+			exec.Command("docker", "info"),
+			filepath.Join(dir, "docker-info.txt"),
+		),
+	}
+
+	// collect /var/log for each node and plan collecting more logs
+	var errs []error
+	for _, n := range nodes {
+		node := n // https://golang.org/doc/faq#closures_and_goroutines
+		name := node.String()
+		path := filepath.Join(dir, name)
+		if err := internallogs.DumpDir(p.logger, node, "/var/log", path); err != nil {
+			errs = append(errs, err)
+		}
+
+		fns = append(fns,
+			func() error { return common.CollectLogs(node, path) },
+			execToPathFn(exec.Command("docker", "inspect", name), filepath.Join(path, "inspect.json")),
+			func() error {
+				f, err := common.FileOnHost(filepath.Join(path, "serial.log"))
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				return node.SerialLogs(f)
+			},
+		)
+	}
+
+	// run and collect up all errors
+	errs = append(errs, errors.AggregateConcurrent(fns))
+	return errors.NewAggregate(errs)
+}
+
+// Info returns the provider info.
+// The info is cached on the first time of the execution.
+func (p *provider) Info() (*providers.ProviderInfo, error) {
+	var err error
+	if p.info == nil {
+		p.info, err = info()
+	}
+	return p.info, err
+}
+
+// dockerInfo corresponds to `docker info --format '{{json .}}'`
+type dockerInfo struct {
+	CgroupDriver    string   `json:"CgroupDriver"`  // "systemd", "cgroupfs", "none"
+	CgroupVersion   string   `json:"CgroupVersion"` // e.g. "2"
+	MemoryLimit     bool     `json:"MemoryLimit"`
+	PidsLimit       bool     `json:"PidsLimit"`
+	CPUShares       bool     `json:"CPUShares"`
+	SecurityOptions []string `json:"SecurityOptions"`
+}
+
+func info() (*providers.ProviderInfo, error) {
+	cmd := exec.Command("docker", "info", "--format", "{{json .}}")
+	out, err := exec.Output(cmd)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get docker info")
+	}
+	var dInfo dockerInfo
+	if err := json.Unmarshal(out, &dInfo); err != nil {
+		return nil, err
+	}
+	info := providers.ProviderInfo{
+		Cgroup2: dInfo.CgroupVersion == "2",
+	}
+	// When CgroupDriver == "none", the MemoryLimit/PidsLimit/CPUShares
+	// values are meaningless and need to be considered false.
+	// https://github.com/moby/moby/issues/42151
+	if dInfo.CgroupDriver != "none" {
+		info.SupportsMemoryLimit = dInfo.MemoryLimit
+		info.SupportsPidsLimit = dInfo.PidsLimit
+		info.SupportsCPUShares = dInfo.CPUShares
+	}
+	for _, o := range dInfo.SecurityOptions {
+		// o is like "name=seccomp,profile=default", or "name=rootless",
+		csvReader := csv.NewReader(strings.NewReader(o))
+		sliceSlice, err := csvReader.ReadAll()
+		if err != nil {
+			return nil, err
+		}
+		for _, f := range sliceSlice {
+			for _, ff := range f {
+				if ff == "name=rootless" {
+					info.Rootless = true
+				}
+			}
+		}
+	}
+	return &info, nil
+}

--- a/pkg/cluster/internal/providers/crafting/provider.go
+++ b/pkg/cluster/internal/providers/crafting/provider.go
@@ -315,14 +315,12 @@ func info() (*providers.ProviderInfo, error) {
 	}
 	info := providers.ProviderInfo{
 		Cgroup2: dInfo.CgroupVersion == "2",
+		// Crafting: In sandbox workspace, let's set these to true
+		SupportsMemoryLimit: true,
+		SupportsPidsLimit:   true,
+		SupportsCPUShares:   true,
+		Rootless:            true,
 	}
-	// Crafting: In sandbox workspace, let's set these to true
-	info.SupportsMemoryLimit = true
-	info.SupportsPidsLimit = true
-	info.SupportsCPUShares = true
-
-	// Crafting: For crafting provider, always rootless
-	info.Rootless = true
 
 	return &info, nil
 }

--- a/pkg/cluster/internal/providers/crafting/provision.go
+++ b/pkg/cluster/internal/providers/crafting/provision.go
@@ -219,7 +219,7 @@ func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, n
 		"--hostname", name, // make hostname match container name
 		// label the node with the role ID
 		"--label", fmt.Sprintf("%s=%s", nodeRoleLabelKey, node.Role),
-		// capabilities
+		// Crafting: capabilities
 		"--cap-add=chown", "--cap-add=dac_override", "--cap-add=fowner", "--cap-add=fsetid", "--cap-add=kill", "--cap-add=setgid",
 		"--cap-add=setuid", "--cap-add=setpcap", "--cap-add=net_bind_service", "--cap-add=net_admin", "--cap-add=net_raw", "--cap-add=sys_chroot",
 		"--cap-add=sys_ptrace", "--cap-add=sys_admin", "--cap-add=mknod", "--cap-add=audit_write", "--cap-add=setfcap",

--- a/pkg/cluster/internal/providers/crafting/provision.go
+++ b/pkg/cluster/internal/providers/crafting/provision.go
@@ -1,0 +1,422 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crafting
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/kind/pkg/cluster/constants"
+	"sigs.k8s.io/kind/pkg/errors"
+	"sigs.k8s.io/kind/pkg/exec"
+	"sigs.k8s.io/kind/pkg/fs"
+
+	"sigs.k8s.io/kind/pkg/cluster/internal/loadbalancer"
+	"sigs.k8s.io/kind/pkg/cluster/internal/providers/common"
+	"sigs.k8s.io/kind/pkg/internal/apis/config"
+)
+
+// planCreation creates a slice of funcs that will create the containers
+func planCreation(cfg *config.Cluster, networkName string) (createContainerFuncs []func() error, err error) {
+	// we need to know all the names for NO_PROXY
+	// compute the names first before any actual node details
+	nodeNamer := common.MakeNodeNamer(cfg.Name)
+	names := make([]string, len(cfg.Nodes))
+	for i, node := range cfg.Nodes {
+		name := nodeNamer(string(node.Role)) // name the node
+		names[i] = name
+	}
+	haveLoadbalancer := config.ClusterHasImplicitLoadBalancer(cfg)
+	if haveLoadbalancer {
+		names = append(names, nodeNamer(constants.ExternalLoadBalancerNodeRoleValue))
+	}
+
+	// these apply to all container creation
+	genericArgs, err := commonArgs(cfg.Name, cfg, networkName, names)
+	if err != nil {
+		return nil, err
+	}
+
+	// only the external LB should reflect the port if we have multiple control planes
+	apiServerPort := cfg.Networking.APIServerPort
+	apiServerAddress := cfg.Networking.APIServerAddress
+	if haveLoadbalancer {
+		// TODO: picking ports locally is less than ideal with remote docker
+		// but this is supposed to be an implementation detail and NOT picking
+		// them breaks host reboot ...
+		// For now remote docker + multi control plane is not supported
+		apiServerPort = 0              // replaced with random ports
+		apiServerAddress = "127.0.0.1" // only the LB needs to be non-local
+		// only for IPv6 only clusters
+		if cfg.Networking.IPFamily == config.IPv6Family {
+			apiServerAddress = "::1" // only the LB needs to be non-local
+		}
+		// plan loadbalancer node
+		name := names[len(names)-1]
+		createContainerFuncs = append(createContainerFuncs, func() error {
+			args, err := runArgsForLoadBalancer(cfg, name, genericArgs)
+			if err != nil {
+				return err
+			}
+			return createContainer(name, args)
+		})
+	}
+
+	// plan normal nodes
+	for i, node := range cfg.Nodes {
+		node := node.DeepCopy() // copy so we can modify
+		name := names[i]
+
+		// fixup relative paths, docker can only handle absolute paths
+		for m := range node.ExtraMounts {
+			hostPath := node.ExtraMounts[m].HostPath
+			if !fs.IsAbs(hostPath) {
+				absHostPath, err := filepath.Abs(hostPath)
+				if err != nil {
+					return nil, errors.Wrapf(err, "unable to resolve absolute path for hostPath: %q", hostPath)
+				}
+				node.ExtraMounts[m].HostPath = absHostPath
+			}
+		}
+
+		// plan actual creation based on role
+		switch node.Role {
+		case config.ControlPlaneRole:
+			createContainerFuncs = append(createContainerFuncs, func() error {
+				node.ExtraPortMappings = append(node.ExtraPortMappings,
+					config.PortMapping{
+						ListenAddress: apiServerAddress,
+						HostPort:      apiServerPort,
+						ContainerPort: common.APIServerInternalPort,
+					},
+				)
+				args, err := runArgsForNode(node, cfg.Networking.IPFamily, name, genericArgs)
+				if err != nil {
+					return err
+				}
+				return createContainerWithWaitUntilSystemdReachesMultiUserSystem(name, args)
+			})
+		case config.WorkerRole:
+			createContainerFuncs = append(createContainerFuncs, func() error {
+				args, err := runArgsForNode(node, cfg.Networking.IPFamily, name, genericArgs)
+				if err != nil {
+					return err
+				}
+				return createContainerWithWaitUntilSystemdReachesMultiUserSystem(name, args)
+			})
+		default:
+			return nil, errors.Errorf("unknown node role: %q", node.Role)
+		}
+	}
+	return createContainerFuncs, nil
+}
+
+// commonArgs computes static arguments that apply to all containers
+func commonArgs(cluster string, cfg *config.Cluster, networkName string, nodeNames []string) ([]string, error) {
+	// standard arguments all nodes containers need, computed once
+	args := []string{
+		"--detach", // run the container detached
+		"--tty",    // allocate a tty for entrypoint logs
+		// label the node with the cluster ID
+		"--label", fmt.Sprintf("%s=%s", clusterLabelKey, cluster),
+		// user a user defined docker network so we get embedded DNS
+		"--net", networkName,
+		// Docker supports the following restart modes:
+		// - no
+		// - on-failure[:max-retries]
+		// - unless-stopped
+		// - always
+		// https://docs.docker.com/engine/reference/commandline/run/#restart-policies---restart
+		//
+		// What we desire is:
+		// - restart on host / dockerd reboot
+		// - don't restart for any other reason
+		//
+		// This means:
+		// - no is out of the question ... it never restarts
+		// - always is a poor choice, we'll keep trying to restart nodes that were
+		// never going to work
+		// - unless-stopped will also retry failures indefinitely, similar to always
+		// except that it won't restart when the container is `docker stop`ed
+		// - on-failure is not great, we're only interested in restarting on
+		// reboots, not failures. *however* we can limit the number of retries
+		// *and* it forgets all state on dockerd restart and retries anyhow.
+		// - on-failure:0 is what we want .. restart on failures, except max
+		// retries is 0, so only restart on reboots.
+		// however this _actually_ means the same thing as always
+		// so the closest thing is on-failure:1, which will retry *once*
+		"--restart=on-failure:1",
+		// this can be enabled by default in docker daemon.json, so we explicitly
+		// disable it, we want our entrypoint to be PID1, not docker-init / tini
+		"--init=false",
+		// note: requires API v1.41+ from Dec 2020 in Docker 20.10.0
+		// this is the default with cgroups v2 but not with cgroups v1, unless
+		// overridden in the daemon --default-cgroupns-mode
+		// https://github.com/docker/cli/pull/3699#issuecomment-1191675788
+		// TODO. Need note for below option about cgroup.
+		"--cgroupns=host",
+		"-v", "/sys/fs/cgroup:/sys/fs/cgroup",
+	}
+
+	// enable IPv6 if necessary
+	if config.ClusterHasIPv6(cfg) {
+		args = append(args, "--sysctl=net.ipv6.conf.all.disable_ipv6=0", "--sysctl=net.ipv6.conf.all.forwarding=1")
+	}
+
+	// pass proxy environment variables
+	proxyEnv, err := getProxyEnv(cfg, networkName, nodeNames)
+	if err != nil {
+		return nil, errors.Wrap(err, "proxy setup error")
+	}
+	for key, val := range proxyEnv {
+		args = append(args, "-e", fmt.Sprintf("%s=%s", key, val))
+	}
+
+	// handle hosts that have user namespace remapping enabled
+	if usernsRemap() {
+		args = append(args, "--userns=host")
+	}
+
+	// handle Docker on Btrfs or ZFS
+	// https://github.com/kubernetes-sigs/kind/issues/1416#issuecomment-606514724
+	if mountDevMapper() {
+		args = append(args, "--volume", "/dev/mapper:/dev/mapper")
+	}
+
+	// enable /dev/fuse explicitly for fuse-overlayfs
+	// (Rootless Docker does not automatically mount /dev/fuse with --privileged)
+	if mountFuse() {
+		args = append(args, "--device", "/dev/fuse")
+	}
+
+	if cfg.Networking.DNSSearch != nil {
+		args = append(args, "-e", "KIND_DNS_SEARCH="+strings.Join(*cfg.Networking.DNSSearch, " "))
+	}
+
+	return args, nil
+}
+
+func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, name string, args []string) ([]string, error) {
+	args = append([]string{
+		"--hostname", name, // make hostname match container name
+		// label the node with the role ID
+		"--label", fmt.Sprintf("%s=%s", nodeRoleLabelKey, node.Role),
+		// capabilities
+		"--cap-add=chown", "--cap-add=dac_override", "--cap-add=fowner", "--cap-add=fsetid", "--cap-add=kill", "--cap-add=setgid",
+		"--cap-add=setuid", "--cap-add=setpcap", "--cap-add=net_bind_service", "--cap-add=net_admin", "--cap-add=net_raw", "--cap-add=sys_chroot",
+		"--cap-add=sys_ptrace", "--cap-add=sys_admin", "--cap-add=mknod", "--cap-add=audit_write", "--cap-add=setfcap",
+
+		"--security-opt", "seccomp=unconfined", // also ignore seccomp
+		"--security-opt", "apparmor=unconfined", // also ignore apparmor
+		// runtime temporary storage
+		"--tmpfs", "/tmp", // various things depend on working /tmp
+		"--tmpfs", "/run", // systemd wants a writable /run
+		// runtime persistent storage
+		// this ensures that E.G. pods, logs etc. are not on the container
+		// filesystem, which is not only better for performance, but allows
+		// running kind in kind for "party tricks"
+		// (please don't depend on doing this though!)
+		"--volume", "/var",
+		// some k8s things want to read /lib/modules
+		"--volume", "/lib/modules:/lib/modules:ro",
+		// propagate KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER to the entrypoint script
+		"-e", "KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER",
+	},
+		args...,
+	)
+
+	// convert mounts and port mappings to container run args
+	args = append(args, generateMountBindings(node.ExtraMounts...)...)
+	mappingArgs, err := generatePortMappings(clusterIPFamily, node.ExtraPortMappings...)
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, mappingArgs...)
+
+	switch node.Role {
+	case config.ControlPlaneRole:
+		args = append(args, "-e", "KUBECONFIG=/etc/kubernetes/admin.conf")
+	}
+
+	// finally, specify the image to run
+	return append(args, node.Image), nil
+}
+
+func runArgsForLoadBalancer(cfg *config.Cluster, name string, args []string) ([]string, error) {
+	args = append([]string{
+		"--hostname", name, // make hostname match container name
+		// label the node with the role ID
+		"--label", fmt.Sprintf("%s=%s", nodeRoleLabelKey, constants.ExternalLoadBalancerNodeRoleValue),
+	},
+		args...,
+	)
+
+	// load balancer port mapping
+	mappingArgs, err := generatePortMappings(cfg.Networking.IPFamily,
+		config.PortMapping{
+			ListenAddress: cfg.Networking.APIServerAddress,
+			HostPort:      cfg.Networking.APIServerPort,
+			ContainerPort: common.APIServerInternalPort,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, mappingArgs...)
+
+	// finally, specify the image to run
+	return append(args, loadbalancer.Image), nil
+}
+
+func getProxyEnv(cfg *config.Cluster, networkName string, nodeNames []string) (map[string]string, error) {
+	envs := common.GetProxyEnvs(cfg)
+	// Specifically add the docker network subnets to NO_PROXY if we are using a proxy
+	if len(envs) > 0 {
+		subnets, err := getSubnets(networkName)
+		if err != nil {
+			return nil, err
+		}
+
+		noProxyList := append(subnets, envs[common.NOProxy])
+		noProxyList = append(noProxyList, nodeNames...)
+		// Add pod and service dns names to no_proxy to allow in cluster
+		// Note: this is best effort based on the default CoreDNS spec
+		// https://github.com/kubernetes/dns/blob/master/docs/specification.md
+		// Any user created pod/service hostnames, namespaces, custom DNS services
+		// are expected to be no-proxied by the user explicitly.
+		noProxyList = append(noProxyList, ".svc", ".svc.cluster", ".svc.cluster.local")
+		noProxyJoined := strings.Join(noProxyList, ",")
+		envs[common.NOProxy] = noProxyJoined
+		envs[strings.ToLower(common.NOProxy)] = noProxyJoined
+	}
+	return envs, nil
+}
+
+func getSubnets(networkName string) ([]string, error) {
+	format := `{{range (index (index . "IPAM") "Config")}}{{index . "Subnet"}} {{end}}`
+	cmd := exec.Command("docker", "network", "inspect", "-f", format, networkName)
+	lines, err := exec.OutputLines(cmd)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get subnets")
+	}
+	return strings.Split(strings.TrimSpace(lines[0]), " "), nil
+}
+
+// generateMountBindings converts the mount list to a list of args for docker
+// '<HostPath>:<ContainerPath>[:options]', where 'options'
+// is a comma-separated list of the following strings:
+// 'ro', if the path is read only
+// 'Z', if the volume requires SELinux relabeling
+func generateMountBindings(mounts ...config.Mount) []string {
+	args := make([]string, 0, len(mounts))
+	for _, m := range mounts {
+		bind := fmt.Sprintf("%s:%s", m.HostPath, m.ContainerPath)
+		var attrs []string
+		if m.Readonly {
+			attrs = append(attrs, "ro")
+		}
+		// Only request relabeling if the pod provides an SELinux context. If the pod
+		// does not provide an SELinux context relabeling will label the volume with
+		// the container's randomly allocated MCS label. This would restrict access
+		// to the volume to the container which mounts it first.
+		if m.SelinuxRelabel {
+			attrs = append(attrs, "Z")
+		}
+		switch m.Propagation {
+		case config.MountPropagationNone:
+			// noop, private is default
+		case config.MountPropagationBidirectional:
+			attrs = append(attrs, "rshared")
+		case config.MountPropagationHostToContainer:
+			attrs = append(attrs, "rslave")
+		default: // Falls back to "private"
+		}
+		if len(attrs) > 0 {
+			bind = fmt.Sprintf("%s:%s", bind, strings.Join(attrs, ","))
+		}
+		args = append(args, fmt.Sprintf("--volume=%s", bind))
+	}
+	return args
+}
+
+// generatePortMappings converts the portMappings list to a list of args for docker
+func generatePortMappings(clusterIPFamily config.ClusterIPFamily, portMappings ...config.PortMapping) ([]string, error) {
+	args := make([]string, 0, len(portMappings))
+	for _, pm := range portMappings {
+		// do provider internal defaulting
+		// in a future API revision we will handle this at the API level and remove this
+		if pm.ListenAddress == "" {
+			switch clusterIPFamily {
+			case config.IPv4Family, config.DualStackFamily:
+				pm.ListenAddress = "0.0.0.0" // this is the docker default anyhow
+			case config.IPv6Family:
+				pm.ListenAddress = "::"
+			default:
+				return nil, errors.Errorf("unknown cluster IP family: %v", clusterIPFamily)
+			}
+		}
+		if string(pm.Protocol) == "" {
+			pm.Protocol = config.PortMappingProtocolTCP // TCP is the default
+		}
+
+		// validate that the provider can handle this binding
+		switch pm.Protocol {
+		case config.PortMappingProtocolTCP:
+		case config.PortMappingProtocolUDP:
+		case config.PortMappingProtocolSCTP:
+		default:
+			return nil, errors.Errorf("unknown port mapping protocol: %v", pm.Protocol)
+		}
+
+		// get a random port if necessary (port = 0)
+		hostPort, releaseHostPortFn, err := common.PortOrGetFreePort(pm.HostPort, pm.ListenAddress)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get random host port for port mapping")
+		}
+		if releaseHostPortFn != nil {
+			defer releaseHostPortFn()
+		}
+
+		// generate the actual mapping arg
+		protocol := string(pm.Protocol)
+		hostPortBinding := net.JoinHostPort(pm.ListenAddress, fmt.Sprintf("%d", hostPort))
+		args = append(args, fmt.Sprintf("--publish=%s:%d/%s", hostPortBinding, pm.ContainerPort, protocol))
+	}
+	return args, nil
+}
+
+func createContainer(name string, args []string) error {
+	if err := exec.Command("docker", append([]string{"run", "--name", name}, args...)...).Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createContainerWithWaitUntilSystemdReachesMultiUserSystem(name string, args []string) error {
+	if err := exec.Command("docker", append([]string{"run", "--name", name}, args...)...).Run(); err != nil {
+		return err
+	}
+
+	logCtx, logCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	logCmd := exec.CommandContext(logCtx, "docker", "logs", "-f", name)
+	defer logCancel()
+	return common.WaitUntilLogRegexpMatches(logCtx, logCmd, common.NodeReachedCgroupsReadyRegexp())
+}

--- a/pkg/cluster/internal/providers/crafting/util.go
+++ b/pkg/cluster/internal/providers/crafting/util.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crafting
+
+import (
+	"encoding/json"
+	"strings"
+
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+// usernsRemap checks if userns-remap is enabled in dockerd
+func usernsRemap() bool {
+	cmd := exec.Command("docker", "info", "--format", "'{{json .SecurityOptions}}'")
+	lines, err := exec.OutputLines(cmd)
+	if err != nil {
+		return false
+	}
+	if len(lines) > 0 {
+		if strings.Contains(lines[0], "name=userns") {
+			return true
+		}
+	}
+	return false
+}
+
+// mountDevMapper checks if the Docker storage driver is Btrfs or ZFS
+// or if the backing filesystem is Btrfs
+func mountDevMapper() bool {
+	storage := ""
+	// check the docker storage driver
+	cmd := exec.Command("docker", "info", "-f", "{{.Driver}}")
+	lines, err := exec.OutputLines(cmd)
+	if err != nil || len(lines) != 1 {
+		return false
+	}
+
+	storage = strings.ToLower(strings.TrimSpace(lines[0]))
+	if storage == "btrfs" || storage == "zfs" || storage == "devicemapper" {
+		return true
+	}
+
+	// check the backing file system
+	// docker info -f '{{json .DriverStatus  }}'
+	// [["Backing Filesystem","extfs"],["Supports d_type","true"],["Native Overlay Diff","true"]]
+	cmd = exec.Command("docker", "info", "-f", "{{json .DriverStatus }}")
+	lines, err = exec.OutputLines(cmd)
+	if err != nil || len(lines) != 1 {
+		return false
+	}
+	var dat [][]string
+	if err := json.Unmarshal([]byte(lines[0]), &dat); err != nil {
+		return false
+	}
+	for _, item := range dat {
+		if item[0] == "Backing Filesystem" {
+			storage = strings.ToLower(item[1])
+			break
+		}
+	}
+
+	return storage == "btrfs" || storage == "zfs" || storage == "xfs"
+}
+
+// rootless: use fuse-overlayfs by default
+// https://github.com/kubernetes-sigs/kind/issues/2275
+func mountFuse() bool {
+	i, err := info()
+	if err != nil {
+		return false
+	}
+	if i != nil && i.Rootless {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Changes
* Add crafting provider which is based on the docker provider
  * Replace `--privileged` with `--cap-add`
  * Create ipv4 only network
  * Patch kube-proxy, replace `securityContext`
  * Currently the files in `providers/crafting` are copied from `providers/docker`  ,except `providers/crafting/crafting.go`. And there are some changes in `providers/crafting/network.go` `providers/crafting/provision.go` `providers/crafting/node.go`.  I added the prefix `Crafting:` to comment for these changes in code. When reviewing pr, we could search `Crafting:` to find what we have changed
* Auto use crafting provider if running kind in sandbox workspace
* Ignore systemd check when using crafting provider

Test
```
go build ./cmd/kind
./kind create cluster --loglevel=debug --retain
docker exec -it kind-control-plane bash
# in docker container 
kubectl get pods -A
# delete cluster
./kind delete cluster -n kind
```